### PR TITLE
Change enyo.depends to enyo.load

### DIFF
--- a/source/webOSjs-loader.js
+++ b/source/webOSjs-loader.js
@@ -6,11 +6,11 @@ Loads the cordova.js file for the current platform.
 	if (enyo.platform.webos || window.PalmSystem) {
 		var webOSjsVersion = window.webOSjsVersion || "0.1.0";
 		var fn = "$lib/enyo-webos/assets/webOSjs-" + webOSjsVersion + "/webOS.js";
-		enyo.depends(fn);
+		enyo.load(fn);
 		enyo.ready(function() {
 			if(!window.cordova) {
 				// if Cordova not used, add signal generation for the "menubutton" event used
-				// in webOS.js for legacy webOS and Open webOS for the appmenu 
+				// in webOS.js for legacy webOS and Open webOS for the appmenu
 				document.addEventListener("menubutton", enyo.bind(enyo.Signals, "send", "onmenubutton"), false);
 			}
 		});


### PR DESCRIPTION
Avoid problems with load order due to outside-of-package.js use of enyo.depends

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
