### PR TITLE
BHV-9669: Removed deprecated enyo.store.addSources() call from LS2Source.js.

### DIFF
--- a/source/LS2Source.js
+++ b/source/LS2Source.js
@@ -41,6 +41,3 @@ enyo.kind({
 	//* @protected
 	_serviceOptions: ["service", "method", "subscribe", "resubscribe", "mockFile"]
 });
-//* @protected
-//add to store
-enyo.store.addSources({service:"enyo.LS2Source"});


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
