### PR TITLE
ENYO-1666:add cancel method to stop luna request

### DIFF
--- a/lib/LunaSource.js
+++ b/lib/LunaSource.js
@@ -91,6 +91,17 @@ module.exports = kind(
 	},
 
 	/**
+	* Cancel the request if don't want to receive a responce.
+	*
+	* @param {enyo.ServiceModel} model - Model to commit
+	* @see enyo.LunaSource#cancel
+	* @public
+	*/
+	cancel: function (model) {
+		model.request.cancel(model);
+	},
+
+	/**
 	* @private
 	*/
 	destroy: function (model, opts) {


### PR DESCRIPTION
## Issue 
enyo.LunaSource don't have cancel method to stop request/response handling

## Fix
Add a public method which is wrapping method to cancel the request