### PR TITLE
ENYO-1770: enyo-webos doesn't require events module by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var
 var
 	Signals = require('enyo/Signals');
 
+require('./lib/Events');
 require('./assets/webOSjs-0.1.0/webOS');
 if (!global.cordova) {
 	// if Cordova not used, add signal generation for the "menubutton" event used


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>