### PR TITLE
ENYO-1944: Add "readAlert()" api in enyo-webos

### DIFF
--- a/lib/VoiceReadout.js
+++ b/lib/VoiceReadout.js
@@ -1,0 +1,17 @@
+require('../webOS/webOS');
+
+var
+	options = require('enyo/options');
+
+module.exports = {
+	/**
+	* Read alert message.
+	*
+	* @public
+	*/
+	readAlert: function(s) {
+		if (options.accessibility && window.webOS && window.webOS.voicereadout) {
+			window.webOS.voicereadout.readAlert(s);
+		}
+	}
+};

--- a/lib/VoiceReadout.js
+++ b/lib/VoiceReadout.js
@@ -10,7 +10,7 @@ module.exports = {
 	* @public
 	*/
 	readAlert: function(s) {
-		if (options.accessibility && window.webOS && window.webOS.voicereadout) {
+		if (options.accessibility && window.webOS.voicereadout) {
 			window.webOS.voicereadout.readAlert(s);
 		}
 	}


### PR DESCRIPTION
Add VoiceReadout module to support readAlert function on webOS devices.

https://jira2.lgsvl.com/browse/ENYO-1944
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>