### PR TITLE
ENYO-1960: change name of method which is for handling failure response

### DIFF
--- a/source/LunaSource.js
+++ b/source/LunaSource.js
@@ -11,7 +11,7 @@
 	* @property {Boolean} resubscribe - whether or not the request should resubscribe when an error is returned (default false)
 	* @property {Object} params       - parameters payload to be sent with the service request
 	* @property {Function} success    - callback on request success
-	* @property {Function} fail       - callback on request failure
+	* @property {Function} error       - callback on request failure
 	* @property {Boolean} mock        - if true, <a href='#enyo.MockRequest'>enyo.MockRequest</a> will be used in place of enyo.ServiceRequest
 	* @property {String} mockFile     - specify the json file to read for mock results, rather than autogenerating the filepath
 	* @public

--- a/source/LunaSource.js
+++ b/source/LunaSource.js
@@ -69,8 +69,8 @@
 				}
 			});
 			model.request.error(function (req, res) {
-				if(opts.fail) {
-					opts.fail(res, req);
+				if(opts.error) {
+					opts.error(res, req);
 				}
 			});
 			model.request.go(opts.params || model.params || {});


### PR DESCRIPTION
## Issue
Error handling routine in LunaSource doesn't executed when luna call is failed

## Fix
Change name of method which is for handling failure response. Because enyo.Source bind the method which name is 'error' in there code.
(this is copy of https://github.com/enyojs/enyo-webos/pull/54)

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com