### PR TITLE
ENYO-1960: change name of method which is for handling failure response

### DIFF
--- a/lib/LunaSource.js
+++ b/lib/LunaSource.js
@@ -70,8 +70,8 @@ module.exports = kind(
 			}
 		});
 		model.request.error(function (req, res) {
-			if(opts.fail) {
-				opts.fail(res, req);
+			if(opts.error) {
+				opts.error(res, req);
 			}
 		});
 		model.request.go(opts.params || model.params || {});


### PR DESCRIPTION
## Issue
Error handling routine in LunaSource doesn't executed when luna call is failed

## Fix
Change name of method which is for handling failure response. Because enyo.Source bind the method which name is 'error' in there code.

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com