### PR TITLE
Fixes ENYO-2083

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var
 
 require('./lib/Events');
 require('./webOS/webOS');
+require('./lib/AppInfo');
 if (!global.cordova) {
 	// if Cordova not used, add signal generation for the "menubutton" event used
 	// in webOS.js for legacy webOS and Open webOS for the appmenu

--- a/lib/AppInfo.js
+++ b/lib/AppInfo.js
@@ -1,0 +1,15 @@
+/**
+* Loads the application's appInfo.json file and configures Enyo
+* 
+* @module enyo-webos/AppInfo
+* @private
+*/
+
+var
+	EnyoHistory = require('enyo/History');
+
+global.webOS.fetchAppInfo(function (appInfo) {
+	if (appInfo) {
+		EnyoHistory.set('enabled', !appInfo.disableBackHistoryAPI);
+	}
+});


### PR DESCRIPTION
Move appInfo loader from moonstone to enyo-webos to support disableBackHistoryAPI property

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)