### PR TITLE
Fixes ENYO-2356

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -4,7 +4,8 @@
     "require": false,
     "exports": true,
     "module": true,
-    "module.exports": true
+    "module.exports": true,
+    "JSON": false
   },
   "es3": true,
   "evil": false,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,7 @@ gulp.task('jshint', lint);
 
 function lint () {
 	return gulp
-		.src('./lib/**.js')
+		.src('./lib/**/*.js')
 		.pipe(jshint())
 		.pipe(jshint.reporter(stylish, {verbose: true}))
 		.pipe(jshint.reporter('fail'));


### PR DESCRIPTION
Source wasn't checked by jshint

Correct glob in gulpfile

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)