### PR TITLE
ENYO-1742: Hook webOSMouse event in Events.js

### DIFF
--- a/src/Events.js
+++ b/src/Events.js
@@ -3,7 +3,8 @@ var
 	platform = require('enyo/platform');
 
 var
-	Signals = require('enyo/Signals');
+	Signals = require('enyo/Signals'),
+	Spotlight = require('spotlight');
 
 /**
 * Events are exposed through the {@link enyo.Signals} kind by adding callback handlers.
@@ -54,4 +55,5 @@ if (platform.webos || window.PalmSystem) {
 	for (var i=0, e; (e=wev[i]); i++) {
 		document.addEventListener(e, utils.bind(Signals, 'send', 'on' + e), false);
 	}
+	document.addEventListener('webOSMouse', utils.bind(Spotlight, 'onwebOSMouse'), false);
 }


### PR DESCRIPTION
Issue:
When floating app is getting pointer, foreground app doesn't know about
mouse leave. So, the foregrund app doesn't un-highlight focus when mouse
move to floating app. This resulting in dual focus issue.

Fix:
Add webOS specific event, webOSMouse, to let app know mouse leave and enter.
This event is fired when QT::Leave and QT::Enter event comes.
We hook this event in Events.js and push that to Spotlight lib for
dual focus handling.

Signed-off-by: Kunmyon Choi <kunmyon.choi@lge.com>