### PR TITLE
ENYO-1742: Add dispatcher an webOSMouse event

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 var
 	platform = require('enyo/platform'),
 	logger = require('enyo/logger'),
-	utils = require('enyo/utils');
+	utils = require('enyo/utils'),
+	dispatcher = require('enyo/dispatcher');
 
 var
 	Signals = require('enyo/Signals');
@@ -14,5 +15,6 @@ if (!global.cordova) {
 	// in webOS.js for legacy webOS and Open webOS for the appmenu
 	document.addEventListener('menubutton', utils.bind(Signals, 'send', 'onmenubutton'), false);
 }
+dispatcher.listen(document, 'webOSMouse');
 
 exports.version = '2.6.0-pre.9.dev';


### PR DESCRIPTION
Issue:
When floating app is getting pointer, foreground app doesn't know about
mouse leave. So, the foregrund app doesn't un-highlight focus when mouse
move to floating app. This resulting in dual focus issue.

Fix:
Add webOS specific event, webOSMouse, to let app know mouse leave and
enter. This event is fired when QT::Leave and QT::Enter event comes.
We directly dispatch this event in enyo-webos index.js.
And, force unspot when webOSMouse leave event comes.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi <kunmyon.choi@lge.com>