### PR TITLE
ENYO-2548: Add keyboardStateChange platform specific event

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,5 +16,6 @@ if (!global.cordova) {
 	document.addEventListener('menubutton', utils.bind(Signals, 'send', 'onmenubutton'), false);
 }
 dispatcher.listen(document, 'webOSMouse');
+dispatcher.listen(document, 'keyboardStateChange');
 
 exports.version = '2.6.0-pre.17.1';


### PR DESCRIPTION
Issue:
When VKB is open and mute spotlight on mouse hover over VKB, it is not
able to unmute on VKB hide with 5way. Because, open / close VKB is not
fires window focus / blur event. So, it can break mute / unmute pair.

Fix:
We add handling platform specific event keyboardStateChange and unmute
spotlight only on VKB hide.
We are not mute on VKB show because it should be always do more unmute
then mute to make it safe.

Enyo-1.1-DCO-Signed-off-by: Kunmyon Choi <kunmyon.choi@lge.com>