### PR TITLE
ENYO-1998: Add supports for subscribed requests and cancel function

### DIFF
--- a/src/LunaSource.js
+++ b/src/LunaSource.js
@@ -101,13 +101,13 @@ module.exports = kind(
 	},
 
 	cancel: function (req) {
-		this.removeRequest(req, req.subscribe);
+		this.removeRequest(req);
 		req.originalCancel();
 	},
 
-	removeRequest: function (req, subscribe) {
+	removeRequest: function (req) {
 		var i;
-		if (subscribe) {
+		if (req.subscribe) {
 			i = this.activeSubscriptionRequests.indexOf(req);
 			if (i !== -1) {
 				this.activeSubscriptionRequests.splice(i, 1);
@@ -125,7 +125,9 @@ module.exports = kind(
 			opts.success(res, req);
 		}
 
-		this.removeRequest(req, false);
+		if(!req.subscribe) {
+			this.removeRequest(req);
+		}
 	},
 
 	requestFailure: function (opts, req, error) {
@@ -133,7 +135,7 @@ module.exports = kind(
 			opts.error(error, req);
 		}
 
-		this.removeRequest(req, req.subscribe);
+		this.removeRequest(req);
 	},
 
 	/**

--- a/src/LunaSource.js
+++ b/src/LunaSource.js
@@ -107,12 +107,12 @@ module.exports = kind(
 
 	removeRequest: function (req) {
 		var i;
-		if (req.subscribe && !req.resubscribe) {
+		if (req.subscribe) {
 			i = this.activeSubscriptionRequests.indexOf(req);
 			if (i !== -1) {
 				this.activeSubscriptionRequests.splice(i, 1);
 			}
-		} else if (!req.subscribe) {
+		} else {
 			i = this.activeRequests.indexOf(req);
 			if (i !== -1) {
 				this.activeRequests.splice(i, 1);
@@ -135,7 +135,9 @@ module.exports = kind(
 			opts.error(error, req);
 		}
 
-		this.removeRequest(req);
+		if (!req.resubscribe) {
+			this.removeRequest(req);
+		}
 	},
 
 	/**

--- a/src/LunaSource.js
+++ b/src/LunaSource.js
@@ -26,6 +26,7 @@ var
 * @property {Function} fail       - Callback on request failure
 * @property {Boolean} mock        - If `true`, {@link module:enyo-webos/MockRequest~MockRequest} will be used in place of enyo.ServiceRequest
 * @property {String} mockFile     - Specifies a JSON file to read for mock results, rather than autogenerating the filepath
+* @property {Number} timeout      - The number of milliseconds to wait before failing with a _timeout_ error. This only takes effect for non-zero values.
 * @public
 */
 
@@ -80,7 +81,8 @@ module.exports = kind(
 			method: (opts.method || model.method),
 			subscribe: (opts.subscribe || model.subscribe),
 			resubscribe: (opts.resubscribe || model.resubscribe),
-			mockFile: (opts.mockFile || model.mockFile)
+			mockFile: (opts.mockFile || model.mockFile),
+			timeout: (opts.timeout || model.timeout || 0)
 		};
 		model.request = new Kind(o);
 		model.request.originalCancel = model.request.cancel;

--- a/src/LunaSource.js
+++ b/src/LunaSource.js
@@ -106,17 +106,10 @@ module.exports = kind(
 	},
 
 	removeRequest: function (req) {
-		var i;
 		if (req.subscribe) {
-			i = this.activeSubscriptionRequests.indexOf(req);
-			if (i !== -1) {
-				this.activeSubscriptionRequests.splice(i, 1);
-			}
+			utils.remove(this.activeSubscriptionRequests, req);
 		} else {
-			i = this.activeRequests.indexOf(req);
-			if (i !== -1) {
-				this.activeRequests.splice(i, 1);
-			}
+			utils.remove(this.activeRequests, req);
 		}
 	},
 

--- a/src/LunaSource.js
+++ b/src/LunaSource.js
@@ -107,12 +107,12 @@ module.exports = kind(
 
 	removeRequest: function (req) {
 		var i;
-		if (req.subscribe) {
+		if (req.subscribe && !req.resubscribe) {
 			i = this.activeSubscriptionRequests.indexOf(req);
 			if (i !== -1) {
 				this.activeSubscriptionRequests.splice(i, 1);
 			}
-		} else {
+		} else if (!req.subscribe) {
 			i = this.activeRequests.indexOf(req);
 			if (i !== -1) {
 				this.activeRequests.splice(i, 1);


### PR DESCRIPTION
Issue
---
- Reference to subscribed request object is not preserved anywhere, making it garbage collected and lose subscribed callbacks
- There's no way to cancel `LS2Request` with `LunaSource`

Fix
---
- Keep active requests and active subscribed requests references in `LunaSource`
- Create cancel function in LunaSource

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>