### PR TITLE
ENYO-3364: Add condition to check window's activation state before re…

### DIFF
--- a/src/VoiceReadout.js
+++ b/src/VoiceReadout.js
@@ -16,7 +16,7 @@ module.exports = {
 	* @public
 	*/
 	readAlert: function(s, c) {
-		if (options.accessibility && window.webOS.voicereadout) {
+		if (options.accessibility && window.webOS.voicereadout && window.PalmSystem && window.PalmSystem.isActivated) {
 			window.webOS.voicereadout.readAlert(s, c);
 		}
 	}


### PR DESCRIPTION
…adAlert

Although app calls readAlert, we need to guard this in case of window is inactivated.
To resolve this, I added window.PalmSystem.isActivated condition before do readAlert
